### PR TITLE
Update the state if the obstruction sensor was triggered while open or closing.

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -1146,6 +1146,9 @@ static void decode_packet(uint8_t *packet) {
         update_paired_devices(nibble, byte2);
     } else if (cmd == GDO_CMD_BATTERY_STATUS) {
         update_battery_state(byte1);
+    } else if ((g_status.door == GDO_DOOR_STATE_OPEN || g_status.door == GDO_DOOR_STATE_CLOSING) && cmd == GDO_CMD_OBST_1) {
+        g_status.door = GDO_DOOR_STATE_OPEN; // if the obstruction sensor tripped the door will go back to open state.
+        queue_event((gdo_event_t){GDO_EVENT_DOOR_POSITION_UPDATE});
     } else {
         ESP_LOGW(TAG, "Unhandled command: %03x (%s)", cmd, cmd_to_string(cmd));
     }


### PR DESCRIPTION
This fixes an issue that when the garage door reverts it's motion while closing the status doesn't update to reflect the state. In this case, when the door is open or closing and obstructed the door will either remain open or revert to open so an event will be triggered to reflect this for handling by the front end.