### PR TITLE
Fix sync issues on some GDO models.

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -718,7 +718,7 @@ static void gdo_sync_task(void* arg) {
     xQueueReset(gdo_event_queue);
 
     for (;;) {
-        if ((esp_timer_get_time() / 1000) - start_ms > 30000) {
+        if ((esp_timer_get_time() / 1000) - start_ms > 5000) {
             synced = false;
             break;
         }

--- a/gdo.c
+++ b/gdo.c
@@ -723,43 +723,31 @@ static void gdo_sync_task(void* arg) {
             break;
         }
 
-        vTaskDelay(pdMS_TO_TICKS(250));
-
         if (g_status.door == GDO_DOOR_STATE_UNKNOWN) {
-            ESP_LOGI(TAG, "SYNC TASK: Getting status");
+            ESP_LOGV(TAG, "SYNC TASK: Getting status");
             get_status();
+            vTaskDelay(pdMS_TO_TICKS(250));
             continue;
         }
-        if (g_status.openings == 0) {
-            ESP_LOGI(TAG, "SYNC TASK: Getting openings");
-            get_openings();
-            vTaskDelay(pdMS_TO_TICKS(250));
-        }
-        if (g_status.paired_devices.total_all == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
-            ESP_LOGI(TAG, "SYNC TASK: Getting all paired devices");
-            get_paired_devices(GDO_PAIRED_DEVICE_TYPE_ALL);
-            vTaskDelay(pdMS_TO_TICKS(250));
-        }
-        if (g_status.paired_devices.total_remotes == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
-            ESP_LOGI(TAG, "SYNC TASK: Getting remotes");
-            get_paired_devices(GDO_PAIRED_DEVICE_TYPE_REMOTE);
-            vTaskDelay(pdMS_TO_TICKS(250));
-        }
-        if (g_status.paired_devices.total_keypads == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
-            ESP_LOGI(TAG, "SYNC TASK: Getting keypads");
-            get_paired_devices(GDO_PAIRED_DEVICE_TYPE_KEYPAD);
-            vTaskDelay(pdMS_TO_TICKS(250));
-        }
-        if (g_status.paired_devices.total_wall_controls == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
-            ESP_LOGI(TAG, "SYNC TASK: Getting wall controls");
-            get_paired_devices(GDO_PAIRED_DEVICE_TYPE_WALL_CONTROL);
-            vTaskDelay(pdMS_TO_TICKS(250));
-        }
-        if (g_status.paired_devices.total_accessories == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
-            ESP_LOGI(TAG, "SYNC TASK: Getting accessories");
-            get_paired_devices(GDO_PAIRED_DEVICE_TYPE_ACCESSORY);
-            vTaskDelay(pdMS_TO_TICKS(250));
-        }
+
+        get_openings();
+        vTaskDelay(pdMS_TO_TICKS(250));
+
+        get_paired_devices(GDO_PAIRED_DEVICE_TYPE_ALL);
+        vTaskDelay(pdMS_TO_TICKS(250));
+
+        get_paired_devices(GDO_PAIRED_DEVICE_TYPE_REMOTE);
+        vTaskDelay(pdMS_TO_TICKS(250));
+
+
+        get_paired_devices(GDO_PAIRED_DEVICE_TYPE_KEYPAD);
+        vTaskDelay(pdMS_TO_TICKS(250));
+
+        get_paired_devices(GDO_PAIRED_DEVICE_TYPE_WALL_CONTROL);
+        vTaskDelay(pdMS_TO_TICKS(250));
+
+        get_paired_devices(GDO_PAIRED_DEVICE_TYPE_ACCESSORY);
+        vTaskDelay(pdMS_TO_TICKS(250));
 
         break;
     }

--- a/gdo.c
+++ b/gdo.c
@@ -733,32 +733,32 @@ static void gdo_sync_task(void* arg) {
         if (g_status.openings == 0) {
             ESP_LOGI(TAG, "SYNC TASK: Getting openings");
             get_openings();
-            continue;
+            vTaskDelay(pdMS_TO_TICKS(250));
         }
         if (g_status.paired_devices.total_all == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
             ESP_LOGI(TAG, "SYNC TASK: Getting all paired devices");
             get_paired_devices(GDO_PAIRED_DEVICE_TYPE_ALL);
-            continue;
+            vTaskDelay(pdMS_TO_TICKS(250));
         }
         if (g_status.paired_devices.total_remotes == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
             ESP_LOGI(TAG, "SYNC TASK: Getting remotes");
             get_paired_devices(GDO_PAIRED_DEVICE_TYPE_REMOTE);
-            continue;
+            vTaskDelay(pdMS_TO_TICKS(250));
         }
         if (g_status.paired_devices.total_keypads == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
             ESP_LOGI(TAG, "SYNC TASK: Getting keypads");
             get_paired_devices(GDO_PAIRED_DEVICE_TYPE_KEYPAD);
-            continue;
+            vTaskDelay(pdMS_TO_TICKS(250));
         }
         if (g_status.paired_devices.total_wall_controls == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
             ESP_LOGI(TAG, "SYNC TASK: Getting wall controls");
             get_paired_devices(GDO_PAIRED_DEVICE_TYPE_WALL_CONTROL);
-            continue;
+            vTaskDelay(pdMS_TO_TICKS(250));
         }
         if (g_status.paired_devices.total_accessories == GDO_PAIRED_DEVICE_COUNT_UNKNOWN) {
             ESP_LOGI(TAG, "SYNC TASK: Getting accessories");
             get_paired_devices(GDO_PAIRED_DEVICE_TYPE_ACCESSORY);
-            continue;
+            vTaskDelay(pdMS_TO_TICKS(250));
         }
 
         break;


### PR DESCRIPTION
Some garage door openers do not respond to some commands, such as "get openings".
This removes the loop continuation on all commands except "get status" to avoid sync failures.

Also the sync failure timer has been reduced from 30 seconds to 5 to allow faster resyncing if the app needs to update the client id and/or the rolling code counter to re-sync in a timely manner.

