### PR TITLE
Add support for door toggle-only setting.

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -467,16 +467,18 @@ esp_err_t gdo_door_move_to_target(uint32_t target) {
         return ESP_ERR_INVALID_ARG;
     }
 
+    if (target == 0) {
+        return gdo_door_open();
+    }
+
+    if (target == 10000) {
+        return gdo_door_close();
+    }
+
     if (g_status.door_position < 0 || g_status.close_ms == 0 || g_status.open_ms == 0 ||
         g_status.door == GDO_DOOR_STATE_OPENING || g_status.door == GDO_DOOR_STATE_CLOSING) {
         ESP_LOGW(TAG, "Unable to move to target, door position or durations are unknown or door is moving");
         return ESP_ERR_INVALID_STATE;
-    }
-
-    if (target == 0) {
-        return gdo_door_open();
-    } else if (target == 10000) {
-        return gdo_door_close();
     }
 
     gdo_door_action_t action = GDO_DOOR_ACTION_MAX;

--- a/gdo.c
+++ b/gdo.c
@@ -1709,6 +1709,7 @@ static void update_door_state(const gdo_door_state_t door_state) {
 
         g_door_start_moving_ms = 0;
         g_status.motor = GDO_MOTOR_STATE_OFF;
+        g_status.door_target = g_status.door_position;
     }
 
     if (g_status.door == GDO_DOOR_STATE_UNKNOWN &&

--- a/gdo.c
+++ b/gdo.c
@@ -495,7 +495,7 @@ esp_err_t gdo_door_move_to_target(uint32_t target) {
         return ESP_OK;
     }
 
-    if (duration_ms < 1000) {
+    if (duration_ms < 500) {
         ESP_LOGW(TAG, "Duration is too short, ignoring move to target");
         return ESP_ERR_INVALID_ARG;
     }
@@ -944,9 +944,15 @@ static void gdo_sync_task(void* arg) {
 
 done:
     g_status.synced = synced;
-    if (!synced && !g_protocol_forced) {
+
+    if (synced) {
+        if (g_status.protocol & GDO_PROTOCOL_SEC_PLUS_V1) {
+            g_status.toggle_only = true;
+        }
+    } else if (!g_protocol_forced) {
         g_status.protocol = 0;
     }
+
     queue_event((gdo_event_t){GDO_EVENT_SYNC_COMPLETE});
     gdo_sync_task_handle = NULL;
     vTaskDelete(NULL);

--- a/include/gdo.h
+++ b/include/gdo.h
@@ -148,6 +148,8 @@ typedef struct {
     int32_t door_target; // Door target position in percentage (0-10000) [OPEN-CLOSED]
     uint32_t client_id; // Client ID
     uint32_t rolling_code; // Rolling code
+    bool toggle_only; // Used when the door opener only supports the toggle command.
+    gdo_door_state_t last_move_direction; // Last move direction
 } gdo_status_t;
 
 typedef struct {
@@ -410,6 +412,12 @@ esp_err_t gdo_set_close_duration(uint16_t ms);
  * @return ESP_OK on success, ESP_ERR_INVALID_ARG if the time is invalid.
 */
 esp_err_t gdo_set_min_command_interval(uint32_t ms);
+
+/**
+ * @brief Enables or disables the toggle only mode, may be required by openers that do not have obstruction sensors connected.
+ * @param toggle_only true to enable toggle only mode, false to disable.
+ */
+void gdo_set_toggle_only(bool toggle_only);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds support for toggle-only command mode that may be required by some garage door openers. This mode can be enabled/disabled at run time through the `gdo_set_toggle_only` function.

* Improves door position and target tracking 