### PR TITLE
Improve accuracy of gdo_door_move_to_target()

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -501,9 +501,11 @@ esp_err_t gdo_door_move_to_target(uint32_t target) {
     int abs_delta = delta < 0 ? -delta : delta;
 
     if ((uint32_t)abs_delta < MOVE_TO_TARGET_NEAR_THRESHOLD) {
-        ESP_LOGD(TAG, "Already within %.2f%% of target %.2f, no-op",
-                 MOVE_TO_TARGET_NEAR_THRESHOLD / 100.0f, target / 100.0f);
-        g_status.door_target = target;
+        ESP_LOGI(TAG, "Move to target %.2f%% no-op: already within %.2f%% (current %.2f%%)",
+                 target / 100.0f, MOVE_TO_TARGET_NEAR_THRESHOLD / 100.0f,
+                 g_status.door_position / 100.0f);
+        g_status.door_target = g_status.door_position;
+        queue_event((gdo_event_t){GDO_EVENT_DOOR_POSITION_UPDATE});
         return ESP_OK;
     }
 
@@ -518,10 +520,16 @@ esp_err_t gdo_door_move_to_target(uint32_t target) {
     }
 
     if (duration_ms < MOVE_TO_TARGET_MIN_DURATION_MS) {
-        ESP_LOGW(TAG, "Move to target rejected: duration %.0fms < min %" PRIu32
-                 "ms (delta=%d, open_ms=%u, close_ms=%u)",
-                 duration_ms, MOVE_TO_TARGET_MIN_DURATION_MS, delta,
-                 g_status.open_ms, g_status.close_ms);
+        ESP_LOGW(TAG, "Move to target %.2f%% rejected: duration %.0fms < min %" PRIu32
+                 "ms (delta=%d, open_ms=%u, close_ms=%u). Resetting target to current "
+                 "position %.2f%%.",
+                 target / 100.0f, duration_ms, MOVE_TO_TARGET_MIN_DURATION_MS, delta,
+                 g_status.open_ms, g_status.close_ms, g_status.door_position / 100.0f);
+        // Reset the target to the current position and fire a position event so
+        // the host (e.g. cover plugin) can revert any optimistic IS_OPENING /
+        // IS_CLOSING state it set in anticipation of this move.
+        g_status.door_target = g_status.door_position;
+        queue_event((gdo_event_t){GDO_EVENT_DOOR_POSITION_UPDATE});
         return ESP_ERR_INVALID_ARG;
     }
 

--- a/gdo.c
+++ b/gdo.c
@@ -107,6 +107,21 @@ static void *g_user_cb_arg;
 static uint32_t g_tx_delay_ms = 50;
 static portMUX_TYPE gdo_spinlock = portMUX_INITIALIZER_UNLOCKED;
 
+// Empirical offset added to the move-to-target STOP delay to compensate for the
+// difference between OPEN and STOP command latencies. Default 0; tune on the
+// bench by observing actual landing position vs. requested target.
+static const uint32_t MOVE_TO_TARGET_STOP_OFFSET_MS = 0;
+// Minimum commanded motion below which the OPEN->STOP sequence is too short for
+// the GDO to reliably register motion. Reject moves with shorter duration.
+static const uint32_t MOVE_TO_TARGET_MIN_DURATION_MS = 800;
+// If the requested target is within this many units (0.01% per unit) of the
+// current position, treat the call as a no-op rather than issuing a futile move.
+static const uint32_t MOVE_TO_TARGET_NEAR_THRESHOLD = 200;
+// Extra latency to add to the STOP delay when the toggle-only stop-then-open
+// dance is taken — that dance schedules toggles at +500ms and +1000ms before
+// motion starts, so STOP needs to be pushed out to align the motor pulse.
+static const uint32_t MOVE_TO_TARGET_TOGGLE_DANCE_MS = 1000;
+
 
 /******************************* PUBLIC API FUNCTIONS **********************************/
 
@@ -482,35 +497,66 @@ esp_err_t gdo_door_move_to_target(uint32_t target) {
         return ESP_ERR_INVALID_STATE;
     }
 
-    gdo_door_action_t action = GDO_DOOR_ACTION_MAX;
     int delta = g_status.door_position - target;
-    float duration_ms = 0.0f;
-    if (delta < 0) {
-        action = GDO_DOOR_ACTION_CLOSE;
-        duration_ms = (g_status.close_ms / 10000.f) * -delta;
-    } else if (delta > 0) {
-        action = GDO_DOOR_ACTION_OPEN;
-        duration_ms = (g_status.open_ms / 10000.f) * delta;
-    } else {
-        ESP_LOGD(TAG, "Door is already at target %.2f", g_status.door_position / 100.0f);
+    int abs_delta = delta < 0 ? -delta : delta;
+
+    if ((uint32_t)abs_delta < MOVE_TO_TARGET_NEAR_THRESHOLD) {
+        ESP_LOGD(TAG, "Already within %.2f%% of target %.2f, no-op",
+                 MOVE_TO_TARGET_NEAR_THRESHOLD / 100.0f, target / 100.0f);
+        g_status.door_target = target;
         return ESP_OK;
     }
 
-    if (duration_ms < 500) {
-        ESP_LOGW(TAG, "Duration is too short, ignoring move to target");
+    float duration_ms;
+    bool opening;
+    if (delta > 0) {
+        opening = true;
+        duration_ms = (g_status.open_ms / 10000.f) * delta;
+    } else {
+        opening = false;
+        duration_ms = (g_status.close_ms / 10000.f) * -delta;
+    }
+
+    if (duration_ms < MOVE_TO_TARGET_MIN_DURATION_MS) {
+        ESP_LOGW(TAG, "Move to target rejected: duration %.0fms < min %" PRIu32
+                 "ms (delta=%d, open_ms=%u, close_ms=%u)",
+                 duration_ms, MOVE_TO_TARGET_MIN_DURATION_MS, delta,
+                 g_status.open_ms, g_status.close_ms);
         return ESP_ERR_INVALID_ARG;
     }
+
+    // Account for the toggle-only stop-then-open dance latency. gdo_door_open()
+    // schedules toggles at +500 and +1000ms before motion actually starts when
+    // the door is STOPPED with last_move_direction matching the requested
+    // direction. The STOP must be pushed out by that same latency so the motor
+    // sees the intended pulse width.
+    uint32_t stop_delay_ms = (uint32_t)duration_ms + MOVE_TO_TARGET_STOP_OFFSET_MS;
+    if (g_status.toggle_only && g_status.door == GDO_DOOR_STATE_STOPPED &&
+        ((opening && g_status.last_move_direction == GDO_DOOR_STATE_OPENING) ||
+         (!opening && g_status.last_move_direction == GDO_DOOR_STATE_CLOSING))) {
+        stop_delay_ms += MOVE_TO_TARGET_TOGGLE_DANCE_MS;
+    }
+
+    ESP_LOGI(TAG, "Move to target %.2f%% from %.2f%%: %s for %.0fms, STOP scheduled at +%" PRIu32 "ms",
+             target / 100.0f, g_status.door_position / 100.0f,
+             opening ? "OPEN" : "CLOSE", duration_ms, stop_delay_ms);
 
     gdo_sched_cmd_args_t args = {
         .cmd = (uint32_t)GDO_DOOR_ACTION_STOP,
         .door_cmd = true,
     };
-    err = schedule_command(&args, duration_ms * 1000);
+    err = schedule_command(&args, stop_delay_ms * 1000);
     if (err != ESP_OK) {
         return err;
     }
 
-    err = send_door_action(action);
+    // Route through gdo_door_open()/gdo_door_close() so toggle-only / Sec+ v1
+    // openers get the stop-then-open dance for free. Both primitives set
+    // door_target to 0 or 10000; we override with the partial target afterward.
+    // The clamp at update_door_state() only fires when target is in the
+    // *opposite* direction of motion, so the partial target is preserved
+    // through the OPENING/CLOSING transition.
+    err = opening ? gdo_door_open() : gdo_door_close();
     if (err == ESP_OK) {
         g_status.door_target = target;
     }
@@ -1031,7 +1077,20 @@ static void door_position_sync_timer_cb(void* arg) {
 
     g_door_start_moving_ms += duration;
 
-    if (g_status.door_position == 0 || g_status.door_position == 10000) {
+    // For a partial-target move, clamp the estimate at the target and stop the timer.
+    // The motor keeps running until the scheduled STOP fires; letting the estimate
+    // sail past the target is what makes a small physical overshoot look like 10%.
+    bool partial_target_reached =
+        (g_status.door == GDO_DOOR_STATE_OPENING &&
+         g_status.door_target > 0 && g_status.door_position <= g_status.door_target) ||
+        (g_status.door == GDO_DOOR_STATE_CLOSING &&
+         g_status.door_target < 10000 && g_status.door_position >= g_status.door_target);
+
+    if (partial_target_reached) {
+        g_status.door_position = g_status.door_target;
+    }
+
+    if (g_status.door_position == 0 || g_status.door_position == 10000 || partial_target_reached) {
         esp_timer_stop(door_position_sync_timer);
     }
 
@@ -1046,6 +1105,8 @@ static void scheduled_cmd_timer_cb(void* arg) {
     gdo_sched_cmd_args_t *args = (gdo_sched_cmd_args_t*)arg;
 
     if (args->door_cmd) {
+        ESP_LOGI(TAG, "Scheduled door action %" PRIu32 " firing at %.2f%%",
+                 args->cmd, g_status.door_position / 100.0f);
         send_door_action((gdo_door_action_t)args->cmd);
     } else {
         queue_command((gdo_command_t)args->cmd, args->nibble, args->byte1, args->byte2);
@@ -1736,7 +1797,7 @@ static void update_door_state(const gdo_door_state_t door_state) {
 
     if (door_state == GDO_DOOR_STATE_OPENING || door_state == GDO_DOOR_STATE_CLOSING) {
         if (g_status.door_position >= 0 && g_status.close_ms > 0 && g_status.open_ms > 0) {
-            g_door_start_moving_ms = (uint32_t)((esp_timer_get_time() / 1000) - 1000);
+            g_door_start_moving_ms = (uint32_t)(esp_timer_get_time() / 1000);
             if (esp_timer_start_periodic(door_position_sync_timer, 500 * 1000) != ESP_OK) {
                 ESP_LOGE(TAG, "Failed to start door position sync timer");
             }


### PR DESCRIPTION
## Context

`gdo_door_move_to_target(target)` issues an OPEN/CLOSE command and schedules a STOP for `duration_ms = (open_ms or close_ms / 10000) * |delta|` later. In practice the door stops at the wrong percentage and small moves often fail outright. Concrete failures reported on a Sec+ v2 opener with auto-learned `open_ms`/`close_ms`:

1. Open to 70% lands at ~80%
2. Close to 20% lands at ~9%
3. Open from 9% → 24% physically twitches but `door_position` never updates
4. Close from 9% → 4% does not move at all

The bulk of the *reported* overshoot in (1)(2) is in the **position estimate**, not necessarily the physical door — `door_position` was anchored 1000 ms in the past *on top of* the GDO's own status-frame reporting latency, so the first sync tick consumed ~1.5 s of fictitious motion in one jump (~12% on a 12 s door). (3) and (4) are short-move failures where the OPEN→STOP sequence is too brief to register on the motor.

## Changes

### 1. Remove the −1000 ms initialization offset (highest leverage)
At the OPENING/CLOSING transition in `update_door_state()`, anchor `g_door_start_moving_ms` at "now" instead of `now − 1000 ms`. The original offset was *adding to* the GDO's reporting latency, not compensating for it. After this change the first sync tick consumes only the actual elapsed time since the OPENING frame arrived. Costs ~3–5% under-reporting at the start of a move (the door did begin moving a few hundred ms before we heard about it) — much better than the prior +12% over-reporting.

### 2. Clamp the position estimate at `door_target` for partial moves
In `door_position_sync_timer_cb()`, when `door_target` is a partial target (not 0 or 10000) and the estimate has reached or passed it, snap to the target and stop the sync timer. The motor still runs until the scheduled STOP fires, but the user-facing `door_position` no longer sails past target during the residual decel time. Full open/close moves keep the existing run-to-bound behavior.

### 3. Add `MOVE_TO_TARGET_STOP_OFFSET_MS` (default 0)
Tunable additive offset for the STOP delay. The OPEN and STOP TX paths are nearly symmetrical (V2: 2 packets ~50 ms apart in both directions), so the residual is small. Default 0; tune empirically on the bench by observing actual landing position vs. requested target.

### 4. Raise minimum duration; add near-target no-op; verbose reject log
Raised the minimum from 500 ms to 800 ms (`MOVE_TO_TARGET_MIN_DURATION_MS`). The reject path now logs `duration_ms`, `delta`, `open_ms`, `close_ms` at WARN so the floor can be tuned empirically. Added a 200-unit (2%) near-target no-op so fractional position-estimate jitter doesn't trigger futile moves.

### 5. Route through `gdo_door_open()` / `gdo_door_close()` for toggle-only support
`move_to_target()` previously called `send_door_action()` directly, bypassing the stop-then-open toggle dance that `gdo_door_open()` implements for Sec+ v1 / toggle-only openers. Now routes through the primitives and re-applies the partial target afterward. The existing clamp at `update_door_state()` only fires when the target is in the *opposite* direction of motion, so the partial target survives the OPENING/CLOSING transition. On V2 this is a no-op; on V1/toggle-only it's a fix.

When the toggle-only dance is taken (door STOPPED with `last_move_direction` matching the requested direction), the STOP delay is extended by 1000 ms (`MOVE_TO_TARGET_TOGGLE_DANCE_MS`) so the motor sees the intended pulse width.

### 6. Diagnostic timing logs
Added `ESP_LOGI` traces at: move-to-target initiation (logs target, current position, direction, duration, scheduled STOP delay) and scheduled command dispatch (logs which action fired and at what position). ESP-IDF prepends timestamps automatically, so these are sufficient to correlate timing on the bench.

## What is explicitly NOT changed
- Auto-calibration of `open_ms`/`close_ms` — still one-shot at first full cycle.
- The 500 ms position sync interval — still appropriate for 10–20 s travel.
- The optimistic state model (we trust GDO status frames for state transitions).
- `g_door_start_moving_ms` 32-bit wraparound at ~49 day uptime (note for a follow-up; not user-facing here).

## Test plan
- [ ] Builds cleanly under `examples/` with `idf.py build`
- [ ] From CLOSED, `gdo_door_move_to_target(3000)` lands at ~30% closed (70% open) ±2%, both physical and API-reported
- [ ] Same for targets 5000 and 7000 from CLOSED
- [ ] From OPEN, `gdo_door_move_to_target(7000)` lands at ~70% closed ±2%
- [ ] From a mid-travel STOPPED at ~5000:
  - [ ] target 4800 → no-op (ESP_OK, no command sent)
  - [ ] target 4500 → reject with WARN log on a 10 s door (under 800 ms minimum)
  - [ ] target 3000 → moves and lands at ±2%
- [ ] All four originally reported failure scenarios behave correctly (open-to-70 from any start, close-to-20, open 9→24, close 9→4)
- [ ] Watching `GDO_CB_EVENT_DOOR_POSITION` during a partial move: `door_position` monotonically approaches `door_target`, freezes at target, no visible overshoot in the API stream
- [ ] (If a Sec+ v1 / toggle-only opener is available): from STOPPED with `last_move_direction == OPENING`, `move_to_target(<more open>)` triggers the stop-then-open dance and the scheduled STOP lands after motion has begun

## Tuning knobs left for the bench
- `MOVE_TO_TARGET_STOP_OFFSET_MS` — start at 0; if landings show consistent over- or under-shoot in the same direction, adjust.
- `MOVE_TO_TARGET_MIN_DURATION_MS` — 800 ms is a starting guess; raise if short moves still fail to register on the motor; lower if a fast door rejects legitimate small moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)