### PR TITLE
Harden RX path against malformed Sec+2.0 frames (#25)

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -1416,7 +1416,10 @@ static void decode_packet(uint8_t *packet) {
     static uint32_t last_obstruction_time = 0;
     static bool obst_clear_from_status = false;
 
-    decode_wireline(packet, &rolling, &fixed, &data);
+    if (decode_wireline(packet, &rolling, &fixed, &data) != 0) {
+        ESP_LOGD(TAG, "Failed to decode wireline frame; dropping");
+        return;
+    }
 
     data &= ~0xf000;
 
@@ -1769,11 +1772,17 @@ static void update_door_state(const gdo_door_state_t door_state) {
     static int64_t start_opening;
     static int64_t start_closing;
 
+    if (door_state >= GDO_DOOR_STATE_MAX) {
+        ESP_LOGE(TAG, "Invalid door state %d; requesting status", door_state);
+        get_status();
+        return;
+    }
+
     if (door_state == g_status.door) {
         return;
     }
 
-    ESP_LOGD(TAG, "Door state: %s", gdo_door_state_str[door_state]);
+    ESP_LOGD(TAG, "Door state: %s", gdo_door_state_to_string(door_state));
 
     if (!g_status.open_ms) {
         if (door_state == GDO_DOOR_STATE_OPENING && g_status.door == GDO_DOOR_STATE_CLOSED) {
@@ -1911,7 +1920,7 @@ inline static void update_light_state(gdo_light_state_t light_state) {
         return;
     }
 
-    ESP_LOGD(TAG, "Light state: %s", gdo_light_state_str[light_state]);
+    ESP_LOGD(TAG, "Light state: %s", gdo_light_state_to_string(light_state));
     g_status.light = light_state;
     queue_event((gdo_event_t){GDO_EVENT_LIGHT_UPDATE});
 }
@@ -1925,7 +1934,7 @@ inline static void update_lock_state(gdo_lock_state_t lock_state) {
         return;
     }
 
-    ESP_LOGD(TAG, "Lock state: %s", gdo_lock_state_str[lock_state]);
+    ESP_LOGD(TAG, "Lock state: %s", gdo_lock_state_to_string(lock_state));
     g_status.lock = lock_state;
     queue_event((gdo_event_t){GDO_EVENT_LOCK_UPDATE});
 }
@@ -1939,7 +1948,7 @@ inline static void update_obstruction_state(gdo_obstruction_state_t obstruction_
         return;
     }
 
-    ESP_LOGD(TAG, "Obstruction state: %s", gdo_obstruction_state_str[obstruction_state]);
+    ESP_LOGD(TAG, "Obstruction state: %s", gdo_obstruction_state_to_string(obstruction_state));
     if (obstruction_state != g_status.obstruction) {
         g_status.obstruction = obstruction_state;
         queue_event((gdo_event_t){GDO_EVENT_OBST});
@@ -1956,7 +1965,7 @@ inline static void update_learn_state(gdo_learn_state_t learn_state) {
         return;
     }
 
-    ESP_LOGD(TAG, "Learn state: %s", gdo_learn_state_str[learn_state]);
+    ESP_LOGD(TAG, "Learn state: %s", gdo_learn_state_to_string(learn_state));
     g_status.learn = learn_state;
     queue_event((gdo_event_t){GDO_EVENT_LEARN_UPDATE});
     if (learn_state == GDO_LEARN_STATE_INACTIVE && g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2) {
@@ -2021,7 +2030,7 @@ inline static void handle_lock_action(gdo_lock_action_t lock_action) {
  * @param motor_state The new motor state to update to.
 */
 inline static void update_motor_state(gdo_motor_state_t motor_state) {
-    ESP_LOGD(TAG, "Motor state: %s", gdo_motor_state_str[motor_state]);
+    ESP_LOGD(TAG, "Motor state: %s", gdo_motor_state_to_string(motor_state));
     if (motor_state != g_status.motor) {
         g_status.motor = motor_state;
         queue_event((gdo_event_t){GDO_EVENT_MOTOR_UPDATE});
@@ -2033,7 +2042,7 @@ inline static void update_motor_state(gdo_motor_state_t motor_state) {
  * @param button_state The new button state to update to.
 */
 inline static void update_button_state(gdo_button_state_t button_state) {
-    ESP_LOGD(TAG, "Button state: %s", gdo_button_state_str[button_state]);
+    ESP_LOGD(TAG, "Button state: %s", gdo_button_state_to_string(button_state));
     if (button_state == GDO_BUTTON_STATE_RELEASED) {
         get_status();
     }
@@ -2050,7 +2059,7 @@ inline static void update_button_state(gdo_button_state_t button_state) {
  * @param motion_state The new motion state to update to.
 */
 inline static void update_motion_state(gdo_motion_state_t motion_state) {
-    ESP_LOGD(TAG, "Motion state: %s", gdo_motion_state_str[motion_state]);
+    ESP_LOGD(TAG, "Motion state: %s", gdo_motion_state_to_string(motion_state));
     if (motion_state == GDO_MOTION_STATE_DETECTED) {
         esp_timer_stop(motion_detect_timer);
         esp_timer_start_once(motion_detect_timer, 3000 * 1000);
@@ -2128,7 +2137,7 @@ inline static void update_paired_devices(gdo_paired_device_type_t type, uint8_t 
  * @param battery_state The new battery state to update to.
 */
 inline static void update_battery_state(gdo_battery_state_t battery_state) {
-    ESP_LOGD(TAG, "Battery state: %s", gdo_battery_state_str[battery_state]);
+    ESP_LOGD(TAG, "Battery state: %s", gdo_battery_state_to_string(battery_state));
     if (battery_state != g_status.battery) {
         g_status.battery = battery_state;
         queue_event((gdo_event_t){GDO_EVENT_BATTERY_UPDATE});

--- a/gdo_utils.c
+++ b/gdo_utils.c
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stddef.h>
+
 #include "gdo.h"
 #include "gdo_priv.h"
 
@@ -213,58 +215,68 @@ void print_buffer(gdo_protocol_type_t protocol, uint8_t* buf, bool is_tx) {
     }
 }
 
+/*
+ * Bounds-clamped table lookup. Packet-derived values are routed through these
+ * helpers, so any out-of-range index (corrupt frame, unmapped opener state)
+ * must return a safe sentinel rather than reading past the end of the table.
+ * The count is derived from the array itself so it stays correct if entries
+ * are added or removed.
+ */
+#define GDO_STR_LOOKUP(arr, idx) \
+    (((size_t)(idx) < (sizeof(arr) / sizeof((arr)[0])) ? (arr)[(idx)] : "Invalid"))
+
 const char* gdo_door_state_to_string(gdo_door_state_t state) {
-    return gdo_door_state_str[state];
+    return GDO_STR_LOOKUP(gdo_door_state_str, state);
 }
 
 const char* gdo_light_state_to_string(gdo_light_state_t state) {
-    return gdo_light_state_str[state];
+    return GDO_STR_LOOKUP(gdo_light_state_str, state);
 }
 
 const char* gdo_lock_state_to_string(gdo_lock_state_t state) {
-    return gdo_lock_state_str[state];
+    return GDO_STR_LOOKUP(gdo_lock_state_str, state);
 }
 
 const char* gdo_motion_state_to_string(gdo_motion_state_t state) {
-    return gdo_motion_state_str[state];
+    return GDO_STR_LOOKUP(gdo_motion_state_str, state);
 }
 
 const char* gdo_obstruction_state_to_string(gdo_obstruction_state_t state) {
-    return gdo_obstruction_state_str[state];
+    return GDO_STR_LOOKUP(gdo_obstruction_state_str, state);
 }
 
 const char* gdo_motor_state_to_string(gdo_motor_state_t state) {
-    return gdo_motor_state_str[state];
+    return GDO_STR_LOOKUP(gdo_motor_state_str, state);
 }
 
 const char* gdo_button_state_to_string(gdo_button_state_t state) {
-    return gdo_button_state_str[state];
+    return GDO_STR_LOOKUP(gdo_button_state_str, state);
 }
 
 const char* gdo_battery_state_to_string(gdo_battery_state_t state) {
-    return gdo_battery_state_str[state];
+    return GDO_STR_LOOKUP(gdo_battery_state_str, state);
 }
 
 const char* gdo_learn_state_to_string(gdo_learn_state_t state) {
-    return gdo_learn_state_str[state];
+    return GDO_STR_LOOKUP(gdo_learn_state_str, state);
 }
 
 const char* gdo_paired_device_type_to_string(gdo_paired_device_type_t type) {
-    return gdo_paired_device_type_str[type];
+    return GDO_STR_LOOKUP(gdo_paired_device_type_str, type);
 }
 
 const char* gdo_light_action_to_string(gdo_light_action_t action) {
-    return gdo_light_action_str[action];
+    return GDO_STR_LOOKUP(gdo_light_action_str, action);
 }
 
 const char* gdo_lock_action_to_string(gdo_lock_action_t action) {
-    return gdo_lock_action_str[action];
+    return GDO_STR_LOOKUP(gdo_lock_action_str, action);
 }
 
 const char* gdo_door_action_to_string(gdo_door_action_t action) {
-    return gdo_door_action_str[action];
+    return GDO_STR_LOOKUP(gdo_door_action_str, action);
 }
 
 const char* gdo_protocol_type_to_string(gdo_protocol_type_t protocol) {
-    return gdo_protocol_type_str[protocol];
+    return GDO_STR_LOOKUP(gdo_protocol_type_str, protocol);
 }


### PR DESCRIPTION
Fixes #25.

A malformed Security+ 2.0 wireline frame that passes the 3-byte packet signature check could walk the RX parse path into an out-of-bounds array read (reported in the field as a crash on a GDO blaQ — see konnected-io/konnected-esphome#115). The parser trusted packet-derived values as array indices without bounds checking and discarded the decode return code.

## Changes

1. **`gdo.c` `decode_packet()`** — check `decode_wireline()`'s return value and drop the frame with a log on failure, instead of relying on zero-initialized outputs accidentally falling through to "unhandled command".

2. **`gdo.c` `update_door_state()`** — validate the door-state enum at function entry, *before* any array indexing. An out-of-range value (6..255, reachable from a corrupt-but-parity-valid frame or an unmapped opener state) now logs and requests a fresh status instead of reading past `gdo_door_state_str[]`.

3. **`gdo_utils.c`** — add a bounds-clamped `GDO_STR_LOOKUP()` macro (keyed on each table's own `sizeof`-derived element count) and route every `gdo_*_to_string()` helper through it, returning `"Invalid"` for out-of-range indices. Defense-in-depth that contains the whole class of bug, including the ESPHome callback downstream.

4. **`gdo.c`** — route all direct `gdo_*_str[]` log lookups through the now-safe `to_string()` helpers. This also fixes a **second reachable OOB read** in `update_battery_state()`, which indexed a 3-entry table with a full byte (`update_battery_state(byte1)`).

## Verification

ESP-IDF was not available in the working environment for a full `idf.py build`, but the new `GDO_STR_LOOKUP` macro was compiled and unit-tested standalone with `gcc -Wall -Wextra` (no warnings): in-range indices return the correct string, out-of-range indices (including a full-byte 255) return `"Invalid"` rather than reading past the array.

> Note: this is a firmware-hardening change only. It does not address the bus-side signal-integrity trigger on the affected install, which is out of scope for firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
