### PR TITLE
Fix Sec+2.0 obstruction reporting so it updates the moment the beam breaks

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -135,6 +135,13 @@ static const uint32_t OBST_EDGE_DEBOUNCE_MS = 750;
 // window of an obstruction event is stale and must not cancel it. Past the window the
 // bit is trustworthy again, so it can repair a desynced state (the #27 stuck case).
 static const uint32_t OBST_STATUS_CLEAR_GUARD_MS = 5000;
+// An authoritative PAIR_3_RESP 0x09 clear is trailed by one more OBST_1 (the physical
+// clear edge) which must not re-assert obstructed. Bench-measured at 471ms and 734ms on
+// two runs, so OBST_EDGE_DEBOUNCE_MS alone left only 16ms of margin. Suppression is a
+// *one-shot* flag rather than a wider debounce, bounded by this window so it self-expires:
+// an unused flag can never swallow a later genuine trip. The window sits below the minimum
+// observed real-edge spacing (~1055ms) so a genuine re-break still registers.
+static const uint32_t OBST_TRAILING_EDGE_WINDOW_MS = 1000;
 
 
 /******************************* PUBLIC API FUNCTIONS **********************************/
@@ -1428,11 +1435,24 @@ static void decode_packet(uint8_t *packet) {
     uint32_t data = 0;
     uint32_t time_now = esp_timer_get_time() / 1000;
 
+    // Anchor for the STATUS stale-clear guard: the last time obstruction state was settled
+    // by a *status-class* signal (STATUS bit or PAIR_3_RESP).
     static uint32_t last_obstruction_time = 0;
+    // Anchor for the OBST_1 edge debounce. Deliberately separate from last_obstruction_time:
+    // STATUS frames arrive continuously and unrelated to beam edges, so anchoring the edge
+    // debounce to them lets a routine STATUS clear swallow a genuine break edge that happens
+    // to land within OBST_EDGE_DEBOUNCE_MS of it, inverting the toggle phase. Only real
+    // obstruction *edges* stamp this: an OBST_1 toggle, or an authoritative 0x0e/0x09 (whose
+    // trailing clear-edge OBST_1 ~471ms later must still be suppressed).
+    static uint32_t last_obst_edge_time = 0;
     // Set once the opener has confirmed a *sustained* obstruction (PAIR_3_RESP 0x0e or a
     // STATUS obstructed bit). While set, OBST_1 repeats are ignored and the clear is taken
     // from PAIR_3_RESP 0x09 / the STATUS bit rather than from an OBST_1 toggle.
     static bool obst_confirmed = false;
+    // Armed by an authoritative PAIR_3_RESP 0x09 clear; consumed by the single trailing
+    // clear-edge OBST_1 that follows it. One-shot and time-bounded (see
+    // OBST_TRAILING_EDGE_WINDOW_MS) so it cannot swallow a later genuine obstruction.
+    static bool obst_trailing_edge_pending = false;
 
     if (decode_wireline(packet, &rolling, &fixed, &data) != 0) {
         ESP_LOGD(TAG, "Failed to decode wireline frame; dropping");
@@ -1507,15 +1527,26 @@ static void decode_packet(uint8_t *packet) {
          * OBST_1 fires on both the trip and the clear edge with identical payload, and is
          * the only signal for brief/intermittent obstructions -- the STATUS bit and
          * PAIR_3_RESP only track *continuous* obstruction (issue #28) -- so we toggle on it.
-         * Guarded two ways: OBST_EDGE_DEBOUNCE_MS collapses the ~74ms retransmit and the
-         * ~471ms clear-edge OBST_1 that trails an authoritative 0x09/STATUS clear (so it
-         * cannot re-assert obstructed), and once a sustained obstruction is confirmed we
-         * stop toggling entirely -- the clear then comes from 0x09/STATUS, not an OBST_1.
+         * Guarded three ways: OBST_EDGE_DEBOUNCE_MS collapses the ~74ms retransmit; a
+         * one-shot flag absorbs the clear edge trailing an authoritative 0x09 (so it cannot
+         * re-assert obstructed); and once a sustained obstruction is confirmed we stop
+         * toggling entirely -- the clear then comes from 0x09/STATUS, not an OBST_1.
          */
-        if (g_config.obst_from_status && !obst_confirmed &&
-            time_now - last_obstruction_time > OBST_EDGE_DEBOUNCE_MS) {
+        if (g_config.obst_from_status && obst_trailing_edge_pending &&
+            time_now - last_obst_edge_time < OBST_TRAILING_EDGE_WINDOW_MS) {
+            // The clear edge for an obstruction already cleared by 0x09. Absorb it once,
+            // and re-anchor the debounce so this edge's own ~74ms retransmits fall inside
+            // it -- otherwise the retransmit would fall through and toggle obstructed back on.
+            obst_trailing_edge_pending = false;
+            last_obst_edge_time = time_now;
+        } else if (g_config.obst_from_status && !obst_confirmed &&
+            time_now - last_obst_edge_time > OBST_EDGE_DEBOUNCE_MS) {
+            obst_trailing_edge_pending = false;
             update_obstruction_state(g_status.obstruction == GDO_OBSTRUCTION_STATE_OBSTRUCTED ?
                                      GDO_OBSTRUCTION_STATE_CLEAR : GDO_OBSTRUCTION_STATE_OBSTRUCTED);
+            last_obst_edge_time = time_now;
+            // Also arm the STATUS stale-clear guard: the STATUS bit trails the beam by
+            // ~4.4s, so without this a stale "clear" bit would cancel a fresh OBST_1 trip.
             last_obstruction_time = time_now;
         }
     } else if (g_config.obst_from_status && cmd == GDO_CMD_PAIR_3_RESP) {
@@ -1529,11 +1560,17 @@ static void decode_packet(uint8_t *packet) {
             ESP_LOGI(TAG, "Long duration obstruction detected");
             obst_confirmed = true;
             last_obstruction_time = time_now;
+            last_obst_edge_time = time_now;
             update_obstruction_state(GDO_OBSTRUCTION_STATE_OBSTRUCTED);
         } else if (byte1 == 0x09) {
             ESP_LOGI(TAG, "Long duration obstruction cleared");
             obst_confirmed = false;
             last_obstruction_time = time_now;
+            // Anchor and arm the one-shot suppression of the physical clear edge that
+            // trails this marker (bench-measured 471ms and 734ms), so it cannot toggle
+            // obstructed straight back on.
+            last_obst_edge_time = time_now;
+            obst_trailing_edge_pending = true;
             update_obstruction_state(GDO_OBSTRUCTION_STATE_CLEAR);
         }
     } else {

--- a/gdo.c
+++ b/gdo.c
@@ -122,6 +122,20 @@ static const uint32_t MOVE_TO_TARGET_NEAR_THRESHOLD = 200;
 // motion starts, so STOP needs to be pushed out to align the motor pulse.
 static const uint32_t MOVE_TO_TARGET_TOGGLE_DANCE_MS = 1000;
 
+// Security+ 2.0 obstruction timing, measured on a live opener (see issue #28):
+//   - each frame is retransmitted ~74ms apart (same rolling code);
+//   - a genuine beam edge is >= ~1050ms from the next OBST_1;
+//   - the clear-edge OBST_1 trails the PAIR_3_RESP 0x09 clear marker by ~471ms;
+//   - the STATUS obstruction bit lags the beam by ~4.4s.
+// One window collapses the retransmit AND suppresses the trailing clear-edge OBST_1
+// that follows an authoritative 0x09/STATUS clear, while staying below the minimum
+// real-edge spacing so a genuine fast edge is never swallowed.
+static const uint32_t OBST_EDGE_DEBOUNCE_MS = 750;
+// The STATUS obstruction bit lags the beam by ~4.4s, so a "clear" bit seen within this
+// window of an obstruction event is stale and must not cancel it. Past the window the
+// bit is trustworthy again, so it can repair a desynced state (the #27 stuck case).
+static const uint32_t OBST_STATUS_CLEAR_GUARD_MS = 5000;
+
 
 /******************************* PUBLIC API FUNCTIONS **********************************/
 
@@ -1053,9 +1067,10 @@ static void obst_timer_cb(void* arg) {
 
     stats->count = 0;
 
-    if (obs_state != GDO_OBSTRUCTION_STATE_MAX && obs_state != g_status.obstruction) {
+    if (obs_state != GDO_OBSTRUCTION_STATE_MAX) {
+        // update_obstruction_state() already no-ops on an unchanged state and queues
+        // GDO_EVENT_OBST itself; the caller must not queue a second one (double callback).
         update_obstruction_state(obs_state);
-        queue_event((gdo_event_t){GDO_EVENT_OBST});
     }
 }
 
@@ -1414,7 +1429,10 @@ static void decode_packet(uint8_t *packet) {
     uint32_t time_now = esp_timer_get_time() / 1000;
 
     static uint32_t last_obstruction_time = 0;
-    static bool obst_clear_from_status = false;
+    // Set once the opener has confirmed a *sustained* obstruction (PAIR_3_RESP 0x0e or a
+    // STATUS obstructed bit). While set, OBST_1 repeats are ignored and the clear is taken
+    // from PAIR_3_RESP 0x09 / the STATUS bit rather than from an OBST_1 toggle.
+    static bool obst_confirmed = false;
 
     if (decode_wireline(packet, &rolling, &fixed, &data) != 0) {
         ESP_LOGD(TAG, "Failed to decode wireline frame; dropping");
@@ -1442,11 +1460,24 @@ static void decode_packet(uint8_t *packet) {
         update_light_state((gdo_light_state_t)((byte2 >> 1) & 1));
         update_lock_state((gdo_lock_state_t)(byte2 & 1));
         update_learn_state((gdo_learn_state_t)((byte2 >> 5) & 1));
-        if (g_config.obst_from_status &&
-            (g_status.obstruction == GDO_OBSTRUCTION_STATE_MAX || obst_clear_from_status)) {
-            update_obstruction_state((gdo_obstruction_state_t)((byte1 >> 6) & 1));
-            if (g_status.obstruction == GDO_OBSTRUCTION_STATE_CLEAR) {
-                obst_clear_from_status = false;
+        if (g_config.obst_from_status) {
+            // The STATUS obstruction bit (active-low: 1 = clear) lags the beam by ~4.4s
+            // (issue #28), so it is a backstop, not a fast path. Trust "obstructed"
+            // immediately (fail-safe). Only accept "clear" once a sustained obstruction
+            // has been confirmed, on the first frame after boot, or once enough time has
+            // passed that the bit is no longer racing a fresh OBST_1 trip -- that last
+            // case lets a stale bit repair a desynced state without cancelling a real trip.
+            gdo_obstruction_state_t status_obst = (gdo_obstruction_state_t)((byte1 >> 6) & 1);
+            if (status_obst == GDO_OBSTRUCTION_STATE_OBSTRUCTED) {
+                obst_confirmed = true;
+                last_obstruction_time = time_now;
+                update_obstruction_state(GDO_OBSTRUCTION_STATE_OBSTRUCTED);
+            } else if (obst_confirmed ||
+                       g_status.obstruction == GDO_OBSTRUCTION_STATE_MAX ||
+                       time_now - last_obstruction_time > OBST_STATUS_CLEAR_GUARD_MS) {
+                obst_confirmed = false;
+                last_obstruction_time = time_now;
+                update_obstruction_state(GDO_OBSTRUCTION_STATE_CLEAR);
             }
         }
     } else if (cmd == GDO_CMD_LIGHT) {
@@ -1473,27 +1504,37 @@ static void decode_packet(uint8_t *packet) {
         }
 
         /*
-         * The obstruction sensor was triggered so we toggle the reported state here,
-         * but only handle if there has been more than 1 second since the last trigger as sometimes
-         * multiple events are sent.
-         *
-         * If this was a long duration obstruction we will wait for a status update to clear the state
-         * because many obstruction events will be sent when a long obstruction is cleared so this
-         * avoids an incorrect state being reported.
+         * OBST_1 fires on both the trip and the clear edge with identical payload, and is
+         * the only signal for brief/intermittent obstructions -- the STATUS bit and
+         * PAIR_3_RESP only track *continuous* obstruction (issue #28) -- so we toggle on it.
+         * Guarded two ways: OBST_EDGE_DEBOUNCE_MS collapses the ~74ms retransmit and the
+         * ~471ms clear-edge OBST_1 that trails an authoritative 0x09/STATUS clear (so it
+         * cannot re-assert obstructed), and once a sustained obstruction is confirmed we
+         * stop toggling entirely -- the clear then comes from 0x09/STATUS, not an OBST_1.
          */
-        if (g_config.obst_from_status && time_now - last_obstruction_time > 1000) {
-            if (obst_clear_from_status) {
-                get_status();
-            } else {
-                update_obstruction_state(g_status.obstruction == GDO_OBSTRUCTION_STATE_OBSTRUCTED ? GDO_OBSTRUCTION_STATE_CLEAR : GDO_OBSTRUCTION_STATE_OBSTRUCTED);
-            }
+        if (g_config.obst_from_status && !obst_confirmed &&
+            time_now - last_obstruction_time > OBST_EDGE_DEBOUNCE_MS) {
+            update_obstruction_state(g_status.obstruction == GDO_OBSTRUCTION_STATE_OBSTRUCTED ?
+                                     GDO_OBSTRUCTION_STATE_CLEAR : GDO_OBSTRUCTION_STATE_OBSTRUCTED);
             last_obstruction_time = time_now;
         }
     } else if (g_config.obst_from_status && cmd == GDO_CMD_PAIR_3_RESP) {
+        /*
+         * The opener's explicit confirmed-obstruction edge markers for a *sustained*
+         * obstruction, ~3.7s after the physical edge (issue #28). Authoritative: they also
+         * repair an OBST_1 toggle desync. The 0x09 clear branch was previously dropped,
+         * which left long obstructions with no explicit clear -- the root of issue #27.
+         */
         if (byte1 == 0x0e) {
             ESP_LOGI(TAG, "Long duration obstruction detected");
-            obst_clear_from_status = true;
+            obst_confirmed = true;
             last_obstruction_time = time_now;
+            update_obstruction_state(GDO_OBSTRUCTION_STATE_OBSTRUCTED);
+        } else if (byte1 == 0x09) {
+            ESP_LOGI(TAG, "Long duration obstruction cleared");
+            obst_confirmed = false;
+            last_obstruction_time = time_now;
+            update_obstruction_state(GDO_OBSTRUCTION_STATE_CLEAR);
         }
     } else {
         ESP_LOGD(TAG, "Unhandled command: %03x (%s)", cmd, cmd_to_string(cmd));
@@ -1949,10 +1990,8 @@ inline static void update_obstruction_state(gdo_obstruction_state_t obstruction_
     }
 
     ESP_LOGD(TAG, "Obstruction state: %s", gdo_obstruction_state_to_string(obstruction_state));
-    if (obstruction_state != g_status.obstruction) {
-        g_status.obstruction = obstruction_state;
-        queue_event((gdo_event_t){GDO_EVENT_OBST});
-    }
+    g_status.obstruction = obstruction_state;
+    queue_event((gdo_event_t){GDO_EVENT_OBST});
 }
 
 /**


### PR DESCRIPTION
Fixes #27. Fixes #28.

## The problem

On Security+ 2.0 with `obst_from_status`, the reported obstruction state could be wrong and stay wrong. A sustained obstruction never published a `Clear` when it ended, and the state often only corrected itself later when some unrelated action happened to produce a status frame.

## Why it's not a one-liner

The opener doesn't provide a single "is the beam blocked" signal. It provides three, and each one is wrong in a different way. All timings below are measured on a live opener (issue #28), not assumed:

| Signal | What it tells you | Catch |
|---|---|---|
| **`OBST_1` (0x084)** | A beam edge just happened | Fires on **both** break and clear with an identical payload — it says "something changed", not what |
| **`PAIR_3_RESP`** | `0x0e` = obstructed, `0x09` = clear | Authoritative, but arrives **~3.7 s late** and only for *sustained* obstructions |
| **STATUS bit** | Obstructed / clear (active-low) | Authoritative, but lags the beam by **~4.4 s** — so right after a trip it still reads "clear" |

So the only signal fast enough to report a brief obstruction is the one that can't tell you which direction the beam moved, and the two signals that can tell you are seconds behind reality.

## What this PR does

Combine all three, letting each cover the others' blind spots.

- **`OBST_1` is the fast path.** Toggle the state on each edge, so a quick wave through the beam is reported immediately.
- **`PAIR_3_RESP` is the source of truth for sustained obstructions.** `0x0e` sets obstructed, `0x09` sets clear. Handling `0x09` is new — master ignored it, which is why a long obstruction never published its clear. Because these are authoritative, they also repair the toggle if it ever gets out of step.
- **The STATUS bit is a safety-biased backstop.** "Obstructed" is believed immediately (fail-safe). "Clear" is only accepted once the obstruction is confirmed, at boot, or after enough time that the bit can't still be lagging a fresh trip — so a stale reading can repair a stuck state without cancelling a real one.
- **Once an obstruction is confirmed, `OBST_1` toggling stops.** During a long block the opener emits many edges; the clear then comes from `0x09`/STATUS instead, so the state can't flicker.

There is no request/response round trip — state is derived from frames the opener already broadcasts.

The three timing constants (`OBST_EDGE_DEBOUNCE_MS`, `OBST_STATUS_CLEAR_GUARD_MS`, `OBST_TRAILING_EDGE_WINDOW_MS`) are each derived from a measured value and carry the measurement in a comment. Picking these by feel is what sank an earlier attempt at this fix.

## Validated on hardware

Earlier revisions of this branch were reasoned out on paper and were wrong. This one was run on a live Security+ 2.0 opener, and paper analysis had missed two real bugs — both found on the bench and fixed in f0a3f5f:

1. **The edge debounce was anchored to the wrong clock**, so a routine status frame could swallow a genuine break edge. The toggle then inverted and the sensor latched ON after any brief wave. It did not self-correct, because this opener transmits nothing while idle, so the backstop had no frame to arrive on.
2. **The clear edge trailing `0x09` was suppressed with only 16 ms to spare.** It measured 734 ms against a 750 ms window. It's now absorbed by a one-shot flag that is time-bounded, so it self-expires and can never swallow a later genuine trip.

Final results, re-run on a normal non-debug build (no instrumentation, logging stripped as in production):

- Brief wave — trips and clears promptly, both edges honoured
- Sustained block — no false clear during the ~4 s the STATUS bit is still stale, no flicker across the hold, clears ~3.5 s after removal, and no re-trip from the trailing edge
- Rapid repeated trips — no spurious flapping, correct final state
- 10 brief waves + 2 sustained holds (8.8 s and 12.3 s) with zero anomalies

Frame counters confirmed no dropped frames behind any of these results.

## Known limitation

During intermittent waving the opener sometimes reports the clear edge of the first wave and then transmits nothing while the beam is still being interrupted. Obstruction can therefore read clear while physically blocked. The same gesture produced edge spacings of 1059 ms and 5287 ms on two runs. gdolib acts correctly on every frame it receives — the information simply isn't on the wire, so this isn't fixable here.

## Also fixed

On the GPIO obstruction path (`obst_from_status = false`), `obst_timer_cb()` fired the user callback twice per transition — `update_obstruction_state()` already queues `GDO_EVENT_OBST`, and the caller queued a second one. A now-dead duplicate `!=` check inside `update_obstruction_state()` is removed as well; an early return above it already covers that case.

Security+ 1.0 is untouched.
