### PR TITLE
Guard motion events behind a completed Sec+2.0 sync

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -2057,8 +2057,20 @@ inline static void update_button_state(gdo_button_state_t button_state) {
  * @brief Updates the local motion state and queues an event if it has changed.
  * Also starts a timer to clear the motion state if not reset.
  * @param motion_state The new motion state to update to.
+ * @details Motion is a Security+ 2.0 only concept. `gdo_sync_task()` probes for a V2
+ * opener by optimistically setting the protocol to V2 and running the V2 decoder against
+ * a bus that may still turn out to be V1, so the protocol alone does not prove we are
+ * talking to a V2 opener; only a completed sync does. Without the `synced` check a
+ * corrupt V1 frame that happens to satisfy the wireline signature and parity checks can
+ * decode as GDO_CMD_MOTION and publish a motion event on an opener that has no motion
+ * sensor at all.
 */
 inline static void update_motion_state(gdo_motion_state_t motion_state) {
+    if (g_status.protocol != GDO_PROTOCOL_SEC_PLUS_V2 || !g_status.synced) {
+        ESP_LOGD(TAG, "Ignoring motion state on unsynced or non-secplus-v2 opener");
+        return;
+    }
+
     ESP_LOGD(TAG, "Motion state: %s", gdo_motion_state_to_string(motion_state));
     if (motion_state == GDO_MOTION_STATE_DETECTED) {
         esp_timer_stop(motion_detect_timer);
@@ -2070,9 +2082,7 @@ inline static void update_motion_state(gdo_motion_state_t motion_state) {
         queue_event((gdo_event_t){GDO_EVENT_MOTION_UPDATE});
     }
 
-    if (g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2) {
-        get_status();
-    }
+    get_status();
 }
 
 /**


### PR DESCRIPTION
Fixes #30.

## The proposed fix in the issue does not close the window

#30 proposes returning early from `update_motion_state()` unless `g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2`. That check is **always true on the bug path**:

- `decode_packet()` — motion's only producer — is already gated behind `if (g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2)` (`gdo.c:1542`).
- `gdo_sync_task()` sets `g_status.protocol = GDO_PROTOCOL_SEC_PLUS_V2` (`gdo.c:927`) **before** it probes — i.e. for the entire duration of the window in which the V2 decoder runs against a bus that may still be V1.

So when a corrupt V1 frame clears `decode_wireline()`'s signature and parity checks and decodes as `GDO_CMD_MOTION`, `g_status.protocol` already reads `SEC_PLUS_V2`. The guard passes and the event fires anyway. Protocol cannot distinguish "proven V2 opener" from "unproven V2 probe" precisely because the probe is what sets it.

## What this PR does instead

The field that does separate those two states is `g_status.synced` — false for the whole probe, set true only once the V2 handshake actually completes (`gdo.c:1006`). The guard requires both:

```c
if (g_status.protocol != GDO_PROTOCOL_SEC_PLUS_V2 || !g_status.synced) {
    ESP_LOGD(TAG, "Ignoring motion state on unsynced or non-secplus-v2 opener");
    return;
}
```

This is a superset of what the issue asked for: it blocks motion during the unproven probe (the actual field bug) *and* blocks any future non-V2 caller. It sits above the timer arming, so no auto-clear timer is armed for a suppressed event. The trailing `if (protocol == V2) get_status();` is redundant after the early return and becomes unconditional.

## On the issue's "Related, worth considering"

Deliberately **not** implemented here. Suppressing *all* state side-effects until sync succeeds would deadlock sync: `gdo_sync_task` advances its stages by polling `g_status.door` (`gdo.c:941`) and `g_status.openings` (`gdo.c:950`), so gating those on `synced` means sync can never complete. Motion is uniquely safe to gate because nothing in the handshake depends on it. That broader containment needs a separate "probe-provisional" mechanism, not a `synced` gate.

## Behavior change

On genuine Sec+2.0 openers, motion frames arriving during the ~5 s sync window are now dropped. Motion is transient and self-clearing on a 3 s timer, so the next detection publishes normally. Sync does not depend on the incidental `get_status()` that motion used to trigger — the sync loop does its own `get_status()` polling (`gdo.c:943`).

## Verification

Built via the example project with `-DEXTRA_COMPONENT_DIRS` (a plain `idf.py build` silently skips the library). Log confirms `Building C object esp-idf/gdolib/.../gdo.c.obj` and `Linking C static library libgdolib.a`, no errors or warnings.

Not yet validated against a live Sec+1.0 device. The confirming field signal per #30 is `secplus V1 panel emulation failed, trying secplus V2 panel emulation` no longer correlating with `Motion: detected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)